### PR TITLE
Create .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,18 @@
+require: rubocop-rspec
+
+AllCops:
+  TargetRubyVersion: 2.3
+  Exclude:
+    - '.*'
+    - '**/coverage/'
+    - 'bin/**/*'
+    - 'config/routes.rb'
+    - 'db/**/*'
+    - 'log/**/*'
+    - 'org/**/*'
+    - 'public/**/*'
+    - 'tmp/**/*'
+    - 'vendor/**/*'
+    
+Metrics/LineLength:
+  Max: 120


### PR DESCRIPTION
Initial commit for linter configuration

Find the current version here:

https://github.com/BOA-Restrictor/guides/blob/master/style/ruby/.rubocop.yml